### PR TITLE
Add MinHook-based Sleep and QPC hooks

### DIFF
--- a/HookDLL/CMakeLists.txt
+++ b/HookDLL/CMakeLists.txt
@@ -11,7 +11,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Общие исходные файлы
 set(SOURCES
     src/HookMain.cpp
-    src/HookFunctions.cpp
     src/IPC.cpp
     src/TimeController.cpp
 )

--- a/HookDLL/src/HookMain.cpp
+++ b/HookDLL/src/HookMain.cpp
@@ -1,25 +1,61 @@
 #include <Windows.h>
 #include <MinHook.h>
-#include "HookFunctions.h"
 #include "TimeController.h"
 
-BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved)
-{
-    switch (reason)
-    {
-        case DLL_PROCESS_ATTACH:
-            if (MH_Initialize() != MH_OK)
-                return FALSE;
-            
-            if (!InitializeHooks())
-                return FALSE;
-            
-            DisableThreadLibraryCalls(hModule);
-            break;
+// Original function pointers
+using SleepFunc = VOID (WINAPI*)(DWORD);
+using QpcFunc = BOOL (WINAPI*)(LARGE_INTEGER*);
 
-        case DLL_PROCESS_DETACH:
-            MH_Uninitialize();
-            break;
+static SleepFunc TrueSleep = nullptr;
+static QpcFunc TrueQueryPerformanceCounter = nullptr;
+
+// Hooked implementations adjust timing based on the multiplier
+static VOID WINAPI HookedSleep(DWORD dwMilliseconds)
+{
+    if (TrueSleep)
+    {
+        DWORD scaled = static_cast<DWORD>(dwMilliseconds * GetTimeMultiplier());
+        TrueSleep(scaled);
     }
+}
+
+static BOOL WINAPI HookedQueryPerformanceCounter(LARGE_INTEGER* lpPerformanceCount)
+{
+    BOOL result = TrueQueryPerformanceCounter(lpPerformanceCount);
+    if (result)
+    {
+        lpPerformanceCount->QuadPart = static_cast<LONGLONG>(
+            lpPerformanceCount->QuadPart * GetTimeMultiplier());
+    }
+    return result;
+}
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID /*lpReserved*/)
+{
+    if (reason == DLL_PROCESS_ATTACH)
+    {
+        if (MH_Initialize() != MH_OK)
+            return FALSE;
+
+        if (MH_CreateHookApi(L"kernel32", "Sleep", &HookedSleep,
+                             reinterpret_cast<LPVOID*>(&TrueSleep)) != MH_OK)
+            return FALSE;
+
+        if (MH_CreateHookApi(L"kernel32", "QueryPerformanceCounter",
+                             &HookedQueryPerformanceCounter,
+                             reinterpret_cast<LPVOID*>(&TrueQueryPerformanceCounter)) != MH_OK)
+            return FALSE;
+
+        if (MH_EnableHook(MH_ALL_HOOKS) != MH_OK)
+            return FALSE;
+
+        DisableThreadLibraryCalls(hModule);
+    }
+    else if (reason == DLL_PROCESS_DETACH)
+    {
+        MH_DisableHook(MH_ALL_HOOKS);
+        MH_Uninitialize();
+    }
+
     return TRUE;
-} 
+}


### PR DESCRIPTION
## Summary
- create HookMain.cpp that initializes MinHook and hooks Sleep and QueryPerformanceCounter
- update CMakeLists to remove outdated HookFunctions source

## Testing
- `echo "No tests or linters defined"`


------
https://chatgpt.com/codex/tasks/task_e_68507b6b67388325a3a96f481e83367e