### PR TITLE
Add build.ps1 for x64 workflow

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,16 @@
+# Build HookDLL x64
+cmake -B build/x64 -S HookDLL -A x64
+cmake --build build/x64 --config Release
+
+# Copy DLL to Launcher plugins
+$pluginDir = "Launcher/Plugins/HookDLL/x64"
+New-Item -ItemType Directory -Force -Path $pluginDir
+Copy-Item "build/x64/Release/HookDLL_x64.dll" -Destination $pluginDir
+
+# Restore and build the launcher
+cd Launcher
+
+dotnet restore
+
+dotnet build -c Release
+


### PR DESCRIPTION
## Summary
- add a root build.ps1 that compiles the HookDLL x64 variant
- copy resulting DLL into Launcher/Plugins
- run dotnet restore and build commands

## Testing
- `cmake --version`
- `dotnet build Launcher/Launcher.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685089ac382883258ec4f5735be3df5a