### PR TITLE
Disable manual mapping feature

### DIFF
--- a/Launcher/Injector.cs
+++ b/Launcher/Injector.cs
@@ -1,5 +1,4 @@
 using System;
-using ManualMapBridge;
 using System.Runtime.InteropServices;
 
 namespace Launcher
@@ -57,9 +56,10 @@ namespace Launcher
             return thread != IntPtr.Zero;
         }
 
-        public static bool InjectManual(int pid, string dllPath)
+        public static bool InjectDLL(int pid, string dllPath)
         {
-            return ManualMapper.Inject(pid, dllPath);
+            // Manual mapping is not supported; fall back to classic injection.
+            return InjectClassic(pid, dllPath);
         }
     }
 }

--- a/Launcher/MainWindow.xaml
+++ b/Launcher/MainWindow.xaml
@@ -46,9 +46,6 @@
         </StackPanel>
 
         <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Left">
-            <CheckBox x:Name="ManualMappingCheckBox"
-                      Content="Use Manual Mapping"
-                      Margin="0,0,10,0"/>
             <Button x:Name="InjectButton" Content="Inject" Width="75" Margin="0,0,10,0"/>
             <Button x:Name="PauseButton" Content="Pause" Width="75"/>
         </StackPanel>

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -13,7 +13,6 @@ namespace Launcher
         private ObservableCollection<ProcessInfo> processes;
         private HotkeyManager hotkeyManager;
         private PipeServer pipeServer;
-        private Injector injector;
         private bool isPaused;
 
         public event PropertyChangedEventHandler? PropertyChanged;
@@ -26,7 +25,6 @@ namespace Launcher
 
             hotkeyManager = new HotkeyManager();
             pipeServer = new PipeServer();
-            injector = new Injector();
             isPaused = false;
 
             Loaded += MainWindow_Loaded;
@@ -83,8 +81,7 @@ namespace Launcher
             string dllPath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
                 $"Plugins/HookDLL/{arch}", dllName);
 
-            bool manual = ManualMappingCheckBox.IsChecked == true;
-            bool result = injector.InjectDLL(info.Id, dllPath, manual);
+            bool result = Injector.InjectDLL(info.Id, dllPath);
 
             MessageBox.Show(result ? "DLL injected" : "Injection failed");
         }

--- a/ManualMapBridge/ManualMapNative.cpp
+++ b/ManualMapBridge/ManualMapNative.cpp
@@ -3,6 +3,10 @@
 
 bool ManualMapNative(int pid, const wchar_t* path)
 {
-    // TODO: Implement actual manual mapping here
+    // Manual mapping is not implemented. Returning false informs the managed
+    // launcher that this feature is unavailable so it can fall back to the
+    // classic LoadLibrary injection method.
+    (void)pid;  // Unused
+    (void)path; // Unused
     return false;
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# GameSpeedController
+
+This repository contains a launcher and hook DLL used for manipulating game speed.
+
+## Manual Mapping
+
+The original UI included a toggle for manual DLL mapping. This feature is not
+implemented and is currently unsupported. The launcher now always uses the
+standard `LoadLibrary` injection method.


### PR DESCRIPTION
## Summary
- disable unsupported ManualMapBridge logic
- remove manual mapping checkbox from the launcher UI
- call classic injection directly
- document the absence of manual mapping support

## Testing
- `dotnet build Launcher/Launcher.csproj -c Release` *(fails: command not found)*
- `msbuild ManualMapBridge/ManualMapBridge.vcxproj /t:Build /p:Configuration=Release` *(fails: command not found)*
- `cmake -B build -S HookDLL` *(fails: platform specification not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6850ab5f98f8832585e5c84a33341233