### PR TITLE
Add injection wrapper method and use static Injector

### DIFF
--- a/Launcher/Injector.cs
+++ b/Launcher/Injector.cs
@@ -61,5 +61,10 @@ namespace Launcher
         {
             return ManualMapper.Inject(pid, dllPath);
         }
+
+        public static bool InjectDLL(int pid, string dllPath, bool manual)
+        {
+            return manual ? InjectManual(pid, dllPath) : InjectClassic(pid, dllPath);
+        }
     }
 }

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -13,7 +13,6 @@ namespace Launcher
         private ObservableCollection<ProcessInfo> processes;
         private HotkeyManager hotkeyManager;
         private PipeServer pipeServer;
-        private Injector injector;
         private bool isPaused;
 
         public event PropertyChangedEventHandler? PropertyChanged;
@@ -26,7 +25,6 @@ namespace Launcher
 
             hotkeyManager = new HotkeyManager();
             pipeServer = new PipeServer();
-            injector = new Injector();
             isPaused = false;
 
             Loaded += MainWindow_Loaded;
@@ -84,7 +82,7 @@ namespace Launcher
                 $"Plugins/HookDLL/{arch}", dllName);
 
             bool manual = ManualMappingCheckBox.IsChecked == true;
-            bool result = injector.InjectDLL(info.Id, dllPath, manual);
+            bool result = Injector.InjectDLL(info.Id, dllPath, manual);
 
             MessageBox.Show(result ? "DLL injected" : "Injection failed");
         }


### PR DESCRIPTION
## Summary
- add `InjectDLL` wrapper to Injector for manual/classic injection
- update `MainWindow` to use static `Injector` methods and remove unused field

## Testing
- `dotnet build Launcher/Launcher.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ab5eb7d08325b84a12cd2d8bb909