### PR TITLE
Add GetTickCount hooks

### DIFF
--- a/HookDLL/src/HookFunctions.h
+++ b/HookDLL/src/HookFunctions.h
@@ -7,7 +7,11 @@ void CleanupHooks();
 // Оригинальные функции
 extern VOID (WINAPI *TrueSleep)(DWORD dwMilliseconds);
 extern BOOL (WINAPI *TrueQueryPerformanceCounter)(LARGE_INTEGER* lpPerformanceCount);
+extern DWORD (WINAPI *TrueGetTickCount)();
+extern ULONGLONG (WINAPI *TrueGetTickCount64)();
 
 // Хуки
 VOID WINAPI HookedSleep(DWORD dwMilliseconds);
-BOOL WINAPI HookedQueryPerformanceCounter(LARGE_INTEGER* lpPerformanceCount); 
+BOOL WINAPI HookedQueryPerformanceCounter(LARGE_INTEGER* lpPerformanceCount);
+DWORD WINAPI HookedGetTickCount();
+ULONGLONG WINAPI HookedGetTickCount64();


### PR DESCRIPTION
## Summary
- hook `GetTickCount` and `GetTickCount64`
- apply `GetTimeMultiplier` to the new hooks
- register the hooks during initialization

## Testing
- `cmake -B build -S HookDLL`
- `cmake --build build --config Release` *(fails: `windows.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6852a885e0bc83258a7f7e9d43de0bfe