### PR TITLE
Use MinHook submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ GameSpeedController is a small experiment for adjusting the speed of Windows app
 - **Visual Studio 2022** with the C++ and .NET desktop workloads
 - **.NET 7 SDK** (required for the WPF launcher)
 - **CMake 3.10** or newer
-- **MinHook** sources placed in `HookDLL/MinHook`
+- **MinHook** submodule in `HookDLL/MinHook`
+
+After cloning the repository, initialize the submodule:
+
+```powershell
+git submodule update --init
+```
 
 ## Building
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,8 +1,8 @@
 # Ensure MinHook is available
 $minHookPath = "HookDLL/MinHook/MinHook.h"
 if (-not (Test-Path $minHookPath)) {
-    Write-Host "MinHook not found. Cloning from GitHub..."
-    git clone https://github.com/TsudaKageyu/minhook.git "HookDLL/MinHook"
+    Write-Error "MinHook submodule not found. Run 'git submodule update --init' first."
+    exit 1
 }
 
 # Build HookDLL x64


### PR DESCRIPTION
## Summary
- update `build.ps1` to require MinHook as a submodule instead of cloning at build time
- document submodule setup step in README

## Testing
- `pwsh -c './build.ps1'` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868861b37e48325a24691a3f2f98628