### PR TITLE
Add hooks for SleepEx and QueryPerformanceFrequency

### DIFF
--- a/HookDLL/src/HookFunctions.h
+++ b/HookDLL/src/HookFunctions.h
@@ -6,12 +6,16 @@ void CleanupHooks();
 
 // Оригинальные функции
 extern VOID (WINAPI *TrueSleep)(DWORD dwMilliseconds);
+extern DWORD (WINAPI *TrueSleepEx)(DWORD dwMilliseconds, BOOL bAlertable);
 extern BOOL (WINAPI *TrueQueryPerformanceCounter)(LARGE_INTEGER* lpPerformanceCount);
+extern BOOL (WINAPI *TrueQueryPerformanceFrequency)(LARGE_INTEGER* lpFrequency);
 extern DWORD (WINAPI *TrueGetTickCount)();
 extern ULONGLONG (WINAPI *TrueGetTickCount64)();
 
 // Хуки
 VOID WINAPI HookedSleep(DWORD dwMilliseconds);
+DWORD WINAPI HookedSleepEx(DWORD dwMilliseconds, BOOL bAlertable);
 BOOL WINAPI HookedQueryPerformanceCounter(LARGE_INTEGER* lpPerformanceCount);
+BOOL WINAPI HookedQueryPerformanceFrequency(LARGE_INTEGER* lpFrequency);
 DWORD WINAPI HookedGetTickCount();
 ULONGLONG WINAPI HookedGetTickCount64();


### PR DESCRIPTION
## Summary
- hook SleepEx and QueryPerformanceFrequency in the DLL
- expose new functions in the header

## Testing
- `cmake -B build -S HookDLL`
- `cmake --build build` *(fails: windows.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868861a29cc8325941b85f691ca7cec