### PR TITLE
Add IPC listener thread

### DIFF
--- a/HookDLL/src/HookMain.cpp
+++ b/HookDLL/src/HookMain.cpp
@@ -2,6 +2,43 @@
 #include <MinHook.h>
 #include "TimeController.h"
 #include "HookFunctions.h"
+#include "IPC.h"
+#include <atomic>
+
+static HANDLE g_ipcThread = nullptr;
+static std::atomic<bool> g_ipcRunning{false};
+static IPCClient g_ipcClient;
+
+DWORD WINAPI IPCThreadProc(LPVOID)
+{
+    const std::wstring pipeName = L"\\\\.\\pipe\\GameSpeedController";
+
+    while (g_ipcRunning)
+    {
+        if (!g_ipcClient.IsConnected())
+        {
+            if (!g_ipcClient.Connect(pipeName))
+            {
+                Sleep(1000);
+                continue;
+            }
+        }
+
+        std::string message;
+        if (g_ipcClient.ReadMessage(message))
+        {
+            ParseIPCCommand(message);
+        }
+        else
+        {
+            g_ipcClient.Disconnect();
+            Sleep(1000);
+        }
+    }
+
+    g_ipcClient.Disconnect();
+    return 0;
+}
 
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID /*lpReserved*/)
@@ -14,10 +51,23 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID /*lpReserved*/)
         if (!InitializeHooks())
             return FALSE;
 
+        g_ipcRunning = true;
+        g_ipcThread = CreateThread(nullptr, 0, IPCThreadProc, nullptr, 0, nullptr);
+
         DisableThreadLibraryCalls(hModule);
     }
     else if (reason == DLL_PROCESS_DETACH)
     {
+        g_ipcRunning = false;
+        if (g_ipcThread)
+        {
+            WaitForSingleObject(g_ipcThread, INFINITE);
+            CloseHandle(g_ipcThread);
+            g_ipcThread = nullptr;
+        }
+
+        g_ipcClient.Disconnect();
+
         CleanupHooks();
         MH_Uninitialize();
     }

--- a/HookDLL/src/IPC.cpp
+++ b/HookDLL/src/IPC.cpp
@@ -48,6 +48,20 @@ bool IPCClient::SendMessage(const std::string& message)
         nullptr) != 0;
 }
 
+bool IPCClient::ReadMessage(std::string& message)
+{
+    if (!m_connected)
+        return false;
+
+    char buffer[1024];
+    DWORD bytesRead = 0;
+    if (!ReadFile(m_pipe, buffer, sizeof(buffer), &bytesRead, nullptr) || bytesRead == 0)
+        return false;
+
+    message.assign(buffer, bytesRead);
+    return true;
+}
+
 bool IPCClient::IsConnected() const
 {
     return m_connected;

--- a/HookDLL/src/IPC.h
+++ b/HookDLL/src/IPC.h
@@ -11,6 +11,7 @@ public:
     bool Connect(const std::wstring& pipeName);
     void Disconnect();
     bool SendMessage(const std::string& message);
+    bool ReadMessage(std::string& message);
     bool IsConnected() const;
 
 private:


### PR DESCRIPTION
## Summary
- extend `IPCClient` with a `ReadMessage` helper
- spin up a background thread in `DllMain` to receive pipe commands
- cleanly stop the thread and disconnect the pipe when the DLL unloads

## Testing
- `cmake -B build -S HookDLL`
- `cmake --build build` *(fails: windows.h not found)*
- `clang-tidy HookDLL/src/HookMain.cpp -- -std=c++17` *(fails: Windows headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686888e781248325af40871126d63995