### PR TITLE
Fix pipe server shutdown

### DIFF
--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -54,6 +54,7 @@ namespace Launcher
         private void MainWindow_Closing(object sender, CancelEventArgs e)
         {
             hotkeyManager.UnregisterHotkeys();
+            pipeServer.Stop();
         }
 
         private void RefreshProcessList()


### PR DESCRIPTION
## Summary
- ensure named pipe server stops when the launcher exits

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686888e82c608325b55fb0a3dfe3d7a5